### PR TITLE
Improve core credits in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ To play Spacewar on your Pocket, please use [this guide](https://www.analogue.co
 ## Credits
 This core is released under the [MIT License](https://github.com/spacemen3/PDP-1/blob/main/LICENSE).
 
-The CPU used in this core is credited to https://github.com/MiSTer-devel/PDP1_MiSTer
+This is a re-implementation of the [fpg1](https://github.com/hrvach/fpg1) core designed by [Hrvoje Čavrak](https://github.com/hrvach) for the [MiSTer FPGA platform](https://mister-devel.github.io/MkDocs_MiSTer/).


### PR DESCRIPTION
Previous discussion was at #1 .

Thank you for your feedback and pull request @birdybro. I am more than happy to highlight the original developer Hrvoje Čavrak (@hrvach) and link to the MiSTer platform.

The only point that I disagree with is labelling this core as a port. While @hrvach's core was a starting point in implementation, the end result differs in a number of significant ways. These include:

- Added adjustable color LUT - [memory.v](https://github.com/spacemen3/PDP-1/blob/main/src/core/PDP-1/memory.v)
- Added config based game setup - [core_top.v](https://github.com/spacemen3/PDP-1/blob/main/src/core/core_top.v)
- Added new CRT renderer - [pdp1_vga_crt.v](https://github.com/spacemen3/PDP-1/blob/main/src/core/PDP-1/pdp1_vga_crt.v)
- Added a tape loader - [tape_drive.v](https://github.com/spacemen3/PDP-1/blob/main/src/core/tape_drive.v)
- Added sleep/wake and memories compatibility for openFPGA (CPU halt and state saving)

For full transparency, these are the parts of the codebase which are still used and not significantly modified from their [original state](https://github.com/hrvach/fpg1/tree/ad7999cb290ccae20bc9112cd0b7bc8ce04bcbcd).

- [cpu.v](https://github.com/spacemen3/PDP-1/blob/main/src/core/PDP-1/cpu.v) was slightly modified to run faster
- [definitions.v](https://github.com/spacemen3/PDP-1/blob/main/src/core/PDP-1/definitions.v)

For these reasons, I would consider this a re-implementation and not a port.